### PR TITLE
Make keyspace a config parameter and have the test suite NOT use the production keyspace.

### DIFF
--- a/esmond/api/tests/test_client.py
+++ b/esmond/api/tests/test_client.py
@@ -36,6 +36,7 @@ class TestClientLibs(LiveServerTestCase):
 
     def test_a_load_data(self):
         config = get_config(get_config_path())
+        config.cassandra_keyspace = 'test_%s'%config.cassandra_keyspace
         config.db_clear_on_testing = True
         
         test_data = load_test_data("rtr_d_ifhcin_long.json")

--- a/esmond/api/tests/test_persist.py
+++ b/esmond/api/tests/test_persist.py
@@ -474,6 +474,7 @@ class TestCassandraPollPersister(TestCase):
 
     def test_sys_uptime(self):
         config = get_config(get_config_path())
+        config.cassandra_keyspace='test_%s'%config.cassandra_keyspace
         q = TestPersistQueue(json.loads(sys_uptime_test_data))
         p = CassandraPollPersister(config, "test", persistq=q)
         p.run()
@@ -494,6 +495,7 @@ class TestCassandraPollPersister(TestCase):
     def test_persister(self):
         """This is a very basic smoke test for a cassandra persister."""
         config = get_config(get_config_path())
+        config.cassandra_keyspace='test_%s'%config.cassandra_keyspace
         test_data = json.loads(timeseries_test_data)
         #return
         q = TestPersistQueue(test_data)
@@ -508,9 +510,10 @@ class TestCassandraPollPersister(TestCase):
         Although this isn't supposed to happen, sometimes it does.
         The example data is real data from conf-rtr.sc13.org."""
         
-        config = get_config(get_config_path())
         test_data = json.loads(backwards_counters_test_data)
 
+        config = get_config(get_config_path())
+        config.cassandra_keyspace='test_%s'%config.cassandra_keyspace
         config.db_clear_on_testing = True
         q = TestPersistQueue(test_data)
         p = CassandraPollPersister(config, "test", persistq=q)
@@ -559,6 +562,7 @@ class TestCassandraPollPersister(TestCase):
         config = get_config(get_config_path())
         test_data = load_test_data("rtr_d_ifhcin_long.json")
         # return
+        config.cassandra_keyspace='test_%s'%config.cassandra_keyspace
         config.db_clear_on_testing = True
         config.db_profile_on_testing = True
 
@@ -629,6 +633,7 @@ class TestCassandraPollPersister(TestCase):
         """Test the hearbeat code"""
 
         config = get_config(get_config_path())
+        config.cassandra_keyspace='test_%s'%config.cassandra_keyspace
 
         freq = 30
         iface = 'GigabitEthernet0/1'
@@ -712,6 +717,7 @@ class TestCassandraPollPersister(TestCase):
         Shows the three query methods that return json formatted data.
         """
         config = get_config(get_config_path())
+        config.cassandra_keyspace='test_%s'%config.cassandra_keyspace
         db = CASSANDRA_DB(config)
         
         start_time = self.ctr.begin*1000
@@ -816,6 +822,7 @@ class TestCassandraApiQueries(ResourceTestCase):
 
     def test_a_load_data(self):
         config = get_config(get_config_path())
+        config.cassandra_keyspace='test_%s'%config.cassandra_keyspace
         config.db_clear_on_testing = True
         # return
         test_data = load_test_data("rtr_d_ifhcin_long.json")
@@ -1407,6 +1414,7 @@ class TestCassandraApiQueriesALU(ResourceTestCase):
 
     def test_a_load_data(self):
         config = get_config(get_config_path())
+        config.cassandra_keyspace='test_%s'%config.cassandra_keyspace
         config.db_clear_on_testing = True
         # return
         test_data = load_test_data("rtr_alu_ifhcin_long.json")

--- a/esmond/cassandra.py
+++ b/esmond/cassandra.py
@@ -80,7 +80,6 @@ class ConnectionException(CassandraException):
         
 class CASSANDRA_DB(object):
     
-    keyspace = 'esmond'
     raw_cf = 'raw_data'
     rate_cf = 'base_rates'
     agg_cf = 'rate_aggregations'
@@ -121,6 +120,7 @@ class CASSANDRA_DB(object):
 
         # Connect to cassandra with SystemManager, do a schema check 
         # and set up schema components if need be.
+        self.keyspace = config.cassandra_keyspace
         try:
             sysman = SystemManager(config.cassandra_servers[0])                              
         except TTransportException, e:

--- a/esmond/config.py
+++ b/esmond/config.py
@@ -52,6 +52,7 @@ class EsmondConfig(object):
         self.api_throttle_at = None
         self.api_throttle_timeframe = None
         self.api_throttle_expiration = None
+        self.cassandra_keyspace = 'esmond'
         self.cassandra_pass = None
         self.cassandra_servers = []
         self.cassandra_user = None

--- a/example_esmond.conf
+++ b/example_esmond.conf
@@ -7,6 +7,7 @@ api_anon_limit = 30
 api_throttle_at = 
 api_throttle_timeframe =
 api_throttle_expiration =
+cassandra_keyspace = 'esmond'
 cassandra_servers = localhost:9160
 cassandra_user =
 cassandra_pass =


### PR DESCRIPTION
The Cassandra keyspace was a fixed parameter. As a result the test suite would use the same keyspace as a running instance of esmond. If esmond was running the keyspace couldn't be dropped so the tests would fail. If esmond was not running the tests would pass but the production data would be lost (whoops!) These changes make the keyspace a config variable which the test suite modifies to try and avoid stomping on the production data.
