### PR TITLE
Skip non-registered event_type; pscheduler-run-href

### DIFF
--- a/esmond_client/clients/esmond-ps-get-bulk
+++ b/esmond_client/clients/esmond-ps-get-bulk
@@ -70,6 +70,10 @@ def main():  # pylint: disable=too-many-locals
         else:
             event_type = [x.event_type for x in meta.get_all_event_types()]
 
+        # Skip non-registered event_type
+        if 'pscheduler-run-href' in event_type:
+            event_type.remove('pscheduler-run-href')
+
         # Loop through the event types
         for etype in event_type:
             print '\n  * processing {0}'.format(etype)


### PR DESCRIPTION
Current `esmond-ps-get-bulk` raise error on a non-registered event type; `pscheduler-run-href`.

```
esmond-ps-get-bulk -o csv -u http://PS_ARCHIVE -S 2018-07-01 -E 2018-07-31 -v
...
Traceback (most recent call last):
  File "PYENV/ESMOND_ENV/bin/esmond-ps-get-bulk", line 104, in <module>
    main()
  File "PYENV/ESMOND_ENV/bin/esmond-ps-get-bulk", line 83, in main
    header, data = data_format_factory(options_wrap, seed_bulk_output=True)(conn)
  File "PYENV/2.7.15/envs/ESMOND_ENV/lib/python2.7/site-packages/esmond_client/perfsonar/util.py", line 607, in data_format_factory
    return format_map.get(event_format(options.type))
  File "PYENV/2.7.15/envs/ESMOND_ENV/lib/python2.7/site-packages/esmond_client/perfsonar/util.py", line 66, in event_format
    return EVENT_MAP[etype]
KeyError: u'pscheduler-run-href'
```