### PR TITLE
Esmond RPM cleanup

### DIFF
--- a/rpm/esmond.spec
+++ b/rpm/esmond.spec
@@ -14,8 +14,8 @@
 %define init_script_2 espersistd
  
 Name:           esmond
-Version:        2.1.3     
-Release:        1%{?dist}
+Version:        4.2.0    
+Release:        0.0.a1%{?dist}
 Summary:        esmond
 Group:          Development/Libraries
 License:        New BSD License 
@@ -42,6 +42,7 @@ Requires:       cassandra20
 Requires:       httpd
 Requires:       mod_ssl
 Requires:       esmond-database
+Requires(post): esmond-database
 Requires:       sqlite
 Requires:       sqlite-devel
 Requires:       memcached
@@ -214,6 +215,11 @@ chown -R esmond:esmond /var/run/esmond
 #fix any file permissions the pip packages mess-up 
 find %{install_base}/lib -type f -perm 0666 -exec chmod 644 {} \;
 
+#run database configuration scripts (dependent on esmond-database package installed)
+for script in %{dbscript_base}/configure-*; do
+    $script $1
+done
+
 #enable and start httpd and cassandra on fresh install
 if [ "$1" = "1" ]; then
     systemctl enable cassandra
@@ -226,8 +232,6 @@ fi
 #try to update the database if this is a clean install
 if [ "$1" = "1" ]; then
     %{dbscript_base}/upgrade-pgsql95.sh
-    %{dbscript_base}/configure-pgsql95.sh
-    systemctl restart httpd
 fi
 
 %postun

--- a/rpm/scripts/configure_esmond
+++ b/rpm/scripts/configure_esmond
@@ -17,4 +17,4 @@ fi
 
 #deploy static files
 mkdir -p ${ESMOND_ROOT}/staticfiles
-django-admin collectstatic --clear --noinput
+django-admin collectstatic --clear --noinput &>> /var/log/esmond/install.log

--- a/rpm/scripts/db/configure-pgsql95.sh
+++ b/rpm/scripts/db/configure-pgsql95.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+PG_VERSION=9.5
+PG_BINDIR=/usr/pgsql-${PG_VERSION}/bin
+PG_DATADIR=/var/lib/pgsql/${PG_VERSION}/data
+PG_SERVICE_NAME="postgresql-${PG_VERSION}"
+
+#init postgres - we shouldn't ever have to do this
+if [ -z "$(ls -A ${PG_DATADIR})" ]; then
+    su -l postgres -c "${PG_BINDIR}/initdb  --locale='C' --encoding='sql_ascii' --pgdata='${PG_DATADIR}' --auth='trust'"
+fi
+
+#fix update error in pg_hba.conf - can remove after 4.0rcs have been out for awhile
+if [ -f "${PG_DATADIR}/pg_hba.conf" ]; then
+    # Remove #BEGIN-xxx that got jammed up onto previous lines
+    sed -i -e 's/\(.\)\(#BEGIN-\)/\1\n\2/' "${PG_DATADIR}/pg_hba.conf"
+    # Remove stock pg_hba line that got jammed up on an #END
+    sed -i -e 's/#END-esmondlocal/#END-esmond\nlocal/g' "${PG_DATADIR}/pg_hba.conf"
+fi
+
+#make sure postgresql is running
+/sbin/service ${PG_SERVICE_NAME} status &> /dev/null
+if [ $? -ne 0 ]; then
+    /sbin/service ${PG_SERVICE_NAME} restart 
+    if [ $? -ne 0 ]; then
+        echo "Unable to start ${PG_SERVICE_NAME}. Your esmond database may not be initialized"
+        exit 1
+    fi
+fi
+
+#create user if not exists or is an old user
+USER_EXISTS=$(su -l postgres -c "psql -tAc \"SELECT 1 FROM pg_roles WHERE rolname='esmond'\"" 2> /dev/null)
+if [ $? -ne 0 ]; then
+    echo "Unable to connect to postgresql to check user. Your esmond database may not be initialized"
+    exit 1
+fi
+OLD_USER_EXISTS=$(su -l postgres -c "psql -tAc \"SELECT 1 FROM pg_authid WHERE rolpassword='md5' || md5('7hc4m1' || rolname)\"" 2> /dev/null)
+if [ $? -ne 0 ]; then
+    echo "Unable to connect to postgresql to check for old users. Your esmond database may not be initialized"
+    exit 1
+fi
+if [ "$USER_EXISTS" != "1" ] || [ "$OLD_USER_EXISTS" == "1" ]; then
+    DB_PASSWORD=$(< /dev/urandom tr -dc _A-Za-z0-9 | head -c32;echo;)
+    if [ "$USER_EXISTS" == "1" ]; then
+        su -l postgres -c "psql -c \"ALTER ROLE esmond WITH PASSWORD '${DB_PASSWORD}'\"" &> /dev/null
+    else
+        su -l postgres -c "psql -c \"CREATE USER esmond WITH PASSWORD '${DB_PASSWORD}'\"" &> /dev/null
+        su -l postgres -c "psql -c \"CREATE DATABASE esmond\"" &> /dev/null
+        su -l postgres -c "psql -c \"GRANT ALL ON DATABASE esmond to esmond\"" &> /dev/null
+    fi
+    sed -i "s/sql_db_name = .*/sql_db_name = esmond/g" /etc/esmond/esmond.conf
+    sed -i "s/sql_db_user = .*/sql_db_user = esmond/g" /etc/esmond/esmond.conf
+    sed -i "s/sql_db_password = .*/sql_db_password = ${DB_PASSWORD}/g" /etc/esmond/esmond.conf
+    drop-in -n -t esmond - ${PG_DATADIR}/pg_hba.conf <<EOF
+#
+# esmond
+#
+# This user should never need to access the database from anywhere
+# other than locally.
+#
+local     esmond          esmond                            md5
+host      esmond          esmond     127.0.0.1/32           md5
+host      esmond          esmond     ::1/128                md5
+EOF
+    /sbin/service ${PG_SERVICE_NAME} restart 
+    if [ $? -ne 0 ]; then
+        echo "Unable to restart ${PG_SERVICE_NAME}. Your esmond database may not be initialized"
+    fi
+fi
+
+#set esmond env variables
+export ESMOND_ROOT=/usr/lib/esmond
+export ESMOND_CONF=/etc/esmond/esmond.conf
+export DJANGO_SETTINGS_MODULE=esmond.settings
+
+#initialize python
+cd $ESMOND_ROOT
+if [ -e /opt/rh/python27/enable ]; then
+    source /opt/rh/python27/enable
+    /opt/rh/python27/root/usr/bin/virtualenv --prompt="(esmond)" .
+fi
+. bin/activate
+
+#build esmond tables
+python esmond/manage.py makemigrations --noinput &> /dev/null
+python esmond/manage.py migrate --noinput &> /dev/null

--- a/rpm/scripts/db/configure-pgsql95.sh
+++ b/rpm/scripts/db/configure-pgsql95.sh
@@ -74,10 +74,6 @@ export DJANGO_SETTINGS_MODULE=esmond.settings
 
 #initialize python
 cd $ESMOND_ROOT
-if [ -e /opt/rh/python27/enable ]; then
-    source /opt/rh/python27/enable
-    /opt/rh/python27/root/usr/bin/virtualenv --prompt="(esmond)" .
-fi
 . bin/activate
 
 #build esmond tables


### PR DESCRIPTION
This pull request aims to have a working installation after doing the RPM install rather than requiring a bunch of extra setup. Specifically it:
- Adds mod_ssl to Requires so apache does SSL by default
- Enables and starts httpd on clean install
- Enables and starts cassandra on clean install
- Sets-up PostgreSQL database

It also drops the esmond-database-postgresql package since it seemed not to work and we don't have the cycles to support anyways. Migration was already in places and this was just a 3.5 backward compatibility thing anyways. 